### PR TITLE
Add config var `S1B_OUT_DIR`

### DIFF
--- a/builder
+++ b/builder
@@ -27,7 +27,10 @@ fi
 readonly aci_dir="${S1B_ACI_DIR}"
 mkdir -p "${aci_dir}"
 
-readonly target_aci="stage1-kvm-${S1B_UPSTREAM_STAGE1_KVM_VERSION}-linux-${kernel_version}.aci"
+readonly out_dir="${S1B_OUT_DIR}"
+mkdir -p "${out_dir}"
+
+readonly target_aci="${out_dir}/stage1-kvm-${S1B_UPSTREAM_STAGE1_KVM_VERSION}-linux-${kernel_version}.aci"
 
 readonly rootfs_dir="${aci_dir}/rootfs"
 mkdir -p "${rootfs_dir}"
@@ -61,6 +64,12 @@ if [[ ! -f "${kernel_config}" ]]; then
     exit 1
   fi
 fi
+
+# stage1 aci already build?
+test -f "${target_aci}" && {
+  echo "${target_aci} exists already, nothing to do" >&2
+  exit 0
+}
 
 # download kernel
 test -f "${kernel_dir}/kernel.tar.xz" || curl -LsS "${kernel_url}" -o "${kernel_dir}/kernel.tar.xz"

--- a/builder-config
+++ b/builder-config
@@ -4,6 +4,9 @@
 # Working directory
 readonly DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# The directory to store the built aci files
+S1B_OUT_DIR="${S1B_OUT_DIR:-${DIR}/aci-files}"
+
 # The kernel version to build and include
 S1B_KERNEL_VERSION="${S1B_KERNEL_VERSION:-"4.9.6"}"
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 dependencies:
   cache_directories:
     - aci
+    - aci-files
     - build
   override:
     - |
@@ -22,6 +23,6 @@ test:
     - |
       true
   post:
-    - mv -v *.aci $CIRCLE_ARTIFACTS/
+    - mv -v aci-files/*.aci $CIRCLE_ARTIFACTS/
     - sha512sum $CIRCLE_ARTIFACTS/*
     - wc -c $CIRCLE_ARTIFACTS/*


### PR DESCRIPTION
Additionally, only rebuild the aci files if they don't exist yet.

Having all aci files in a directory allows us to easily cache them on
Circle CI.