### PR TITLE
circle.yml: install new deps 'bison' and 'flex'

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   override:
     - |
       sudo apt-get update &&
-      sudo apt-get install -y build-essential make rsync curl patch tar gzip libelf-dev
+      sudo apt-get install -y build-essential make rsync curl patch tar gzip libelf-dev bison flex
     - |
       go get github.com/appc/spec/actool
     - |


### PR DESCRIPTION
Since Linux 4.16, bison and flex are required for kernel builds.

https://github.com/torvalds/linux/commit/033dba2ec06c47a9fe1b190bc3281058fb20738d